### PR TITLE
arm64: dts: 60Hz BOE Screen

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-boe-hx8394f-720p-video.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-boe-hx8394f-720p-video.dtsi
@@ -22,7 +22,7 @@
 		qcom,mdss-dsi-panel-name = "boe hx8394f video mode dsi panel";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-type = "dsi_video_mode";
-		qcom,mdss-dsi-panel-framerate = <58>;
+		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-panel-width = <720>;


### PR DESCRIPTION
So let's all consider this was a typo made by Xiaomi 
and set the BOE screen frequency to 60Hz by default just like other screen variants.